### PR TITLE
floor in some instances forces pdfkit to clip out text

### DIFF
--- a/src/elements/paragraph.ts
+++ b/src/elements/paragraph.ts
@@ -18,7 +18,7 @@ export class Paragraph implements Element {
 
   width(context: Context, box: BoundingBox): number {
     return context.withFont(this.style, () => {
-      return Math.floor(
+      return Math.ceil(
         context.raw.widthOfString(this.text, {
           width: box.width,
           height: box.height
@@ -29,7 +29,7 @@ export class Paragraph implements Element {
 
   height(context: Context, box: BoundingBox): number {
     return context.withFont(this.style, () => {
-      return Math.floor(
+      return Math.ceil(
         context.raw.heightOfString(this.text, {
           width: box.width,
           height: box.height

--- a/src/layouts/block.ts
+++ b/src/layouts/block.ts
@@ -19,7 +19,7 @@ export class Block implements Layout {
   }
 
   height(context: Context, box: BoundingBox): number {
-    return Math.floor(sumBy(this.elements, e => e.height(context, box)));
+    return Math.ceil(sumBy(this.elements, e => e.height(context, box)));
   }
 
   draw(context: Context, box: BoundingBox): void {

--- a/src/layouts/flex/equal.ts
+++ b/src/layouts/flex/equal.ts
@@ -20,7 +20,7 @@ export class EqualFlex implements Layout {
   height(context: Context, box: BoundingBox) {
     // we must factor in the width if the individual items when getting their heigth
     const width = box.width / this.items.length;
-    return Math.floor(
+    return Math.ceil(
       Math.max(...this.items.map(i => i.height(context, { ...box, width })))
     );
   }

--- a/src/layouts/flex/ratio.ts
+++ b/src/layouts/flex/ratio.ts
@@ -29,7 +29,7 @@ export class RatioFlex implements Layout {
 
   height(context: Context, box: BoundingBox) {
     const ratioMap = this.getRatioMap(box);
-    return Math.floor(
+    return Math.ceil(
       Math.max(
         ...this.items.map((item, i) =>
           item.height(context, { ...box, width: ratioMap[i] })


### PR DESCRIPTION
## Problem
This issue was discovered when creating a new layout with automatic width calculation, where the width of the text is always smaller than it should be because floor was cutting out the decimals