### PR TITLE
there's no way to set spacing between text lines and characters 

### DIFF
--- a/src/elements/paragraph.ts
+++ b/src/elements/paragraph.ts
@@ -39,10 +39,11 @@ export class Paragraph implements Element {
   }
 
   draw(context: Context, box: BoundingBox): void {
-    const textOptions = {
+    const textOptions: PDFKit.Mixins.TextOptions = {
       width: box.width,
       height: box.height,
-      align: this.style.align
+      align: this.style.align,
+      characterSpacing: this.style.letterSpacing
     };
     context.withFont(this.style, () => {
       return context.raw.text(this.text, box.x, box.y, textOptions);

--- a/src/elements/paragraph.ts
+++ b/src/elements/paragraph.ts
@@ -18,7 +18,7 @@ export class Paragraph implements Element {
 
   width(context: Context, box: BoundingBox): number {
     return context.withFont(this.style, () => {
-      return Math.floor(
+      return Math.ceil(
         context.raw.widthOfString(this.text, {
           width: box.width,
           height: box.height
@@ -29,7 +29,7 @@ export class Paragraph implements Element {
 
   height(context: Context, box: BoundingBox): number {
     return context.withFont(this.style, () => {
-      return Math.floor(
+      return Math.ceil(
         context.raw.heightOfString(this.text, {
           width: box.width,
           height: box.height

--- a/src/layouts/block.ts
+++ b/src/layouts/block.ts
@@ -19,7 +19,7 @@ export class Block implements Layout {
   }
 
   height(context: Context, box: BoundingBox): number {
-    return Math.floor(sumBy(this.elements, e => e.height(context, box)));
+    return Math.ceil(sumBy(this.elements, e => e.height(context, box)));
   }
 
   draw(context: Context, box: BoundingBox): void {

--- a/src/layouts/flex/equal.ts
+++ b/src/layouts/flex/equal.ts
@@ -20,7 +20,7 @@ export class EqualFlex implements Layout {
   height(context: Context, box: BoundingBox) {
     // we must factor in the width if the individual items when getting their heigth
     const width = box.width / this.items.length;
-    return Math.floor(
+    return Math.ceil(
       Math.max(...this.items.map(i => i.height(context, { ...box, width })))
     );
   }

--- a/src/layouts/flex/ratio.ts
+++ b/src/layouts/flex/ratio.ts
@@ -29,7 +29,7 @@ export class RatioFlex implements Layout {
 
   height(context: Context, box: BoundingBox) {
     const ratioMap = this.getRatioMap(box);
-    return Math.floor(
+    return Math.ceil(
       Math.max(
         ...this.items.map((item, i) =>
           item.height(context, { ...box, width: ratioMap[i] })

--- a/src/utils/font.ts
+++ b/src/utils/font.ts
@@ -11,6 +11,8 @@ export interface FontStyle {
   fontSize?: number;
   fontFamily?: string;
   fontColor?: ColorValue;
+  letterSpacing?: number;
+  lineHeight?: number;
 }
 
 /**
@@ -30,4 +32,6 @@ export function switchFont(doc: PDFKit.PDFDocument, config: FontStyle) {
   if (config.fontFamily) doc.font(config.fontFamily);
   if (config.fontSize) doc.fontSize(config.fontSize);
   if (config.fontColor) doc.fillColor(getRGB(config.fontColor));
+  if (config.lineHeight && config.lineHeight >= config.fontSize)
+    doc.lineGap(config.lineHeight - config.fontSize);
 }


### PR DESCRIPTION
## Problem
CSS has tools for spacing lines of text(`line-height`) and characters(`letter-spacing`). `pdfkit` has such but they are inaccessible from the `p` API