### PR TITLE
how do we use images as background for the entire document

### DIFF
--- a/src/base/bounding-box.ts
+++ b/src/base/bounding-box.ts
@@ -49,6 +49,13 @@ export function pageBounds(margins?: Margins): BoundingBox {
 }
 
 /**
+ * Create a bounding box for an entire A4 page
+ */
+export function fullPageBounds(): BoundingBox {
+  return { x: 0, y: 0, width: A4_WIDTH, height: A4_HEIGHT };
+}
+
+/**
  * Resize the box based on the given margins
  * @param box box to be resized
  * @param margins margins to use to resize

--- a/src/elements/background.ts
+++ b/src/elements/background.ts
@@ -41,3 +41,21 @@ export class ElementBackground implements Element {
     this.element.draw(context, box);
   }
 }
+
+/**
+ * `BackgroundImage` is the equivalent of `background-image` CSS property
+ */
+export class ImageBackground implements Drawable {
+  /**
+   * Create a new image without drawing it
+   * @param src path to the source image. For the sake of everyone involved please use an
+   * absolute path
+   */
+  constructor(private src: string) {}
+
+  draw(context: Context, box: BoundingBox): void {
+    context.raw.image(this.src, box.x, box.y, {
+      fit: [box.width, box.height]
+    });
+  }
+}

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -12,6 +12,7 @@ import {
   Background,
   ElementBackground,
   Image,
+  ImageBackground,
   LineBreak,
   Padding,
   Paragraph
@@ -75,6 +76,14 @@ export function col(
 export function bg(color: ColorValue, element?: Element) {
   if (element) return new ElementBackground(color, element);
   else return new Background(color);
+}
+
+/**
+ * Create an image background
+ * @param src path to the image
+ */
+export function imgBg(src: string) {
+  return new ImageBackground(src);
 }
 
 /**


### PR DESCRIPTION
## Problem
Currently users can set a colour as the background for all pages in a document. But most PDF documents from Financial Institutions have branded images that serve as seals as the background for all pages in their statements and such. Cover letters would be impossible with the current way of setting document backgrounds