### PR TITLE
generating boxes for RatioFlex could be simpler

### DIFF
--- a/src/utils/number.ts
+++ b/src/utils/number.ts
@@ -1,3 +1,18 @@
-export function toFixed(num: number) {
+export function truncate(num: number) {
   return Number.parseFloat(num.toFixed(2));
+}
+
+export function formatCurrency(currency: string, amount: number) {
+  if (currency === "NGN") {
+    const amountStr = new Intl.NumberFormat("en-US", {
+      currency: "USD",
+      style: "currency"
+    }).format(amount);
+    return amountStr.replace("$", "₦");
+  }
+
+  new Intl.NumberFormat("en-US", {
+    currency,
+    style: "currency"
+  }).format(amount);
 }


### PR DESCRIPTION
## Problem
We could do without some of the calculations in `RatioFlex.boxes`.
- we don't need floating as we expect the widths to sum up to the containing box's width(hence the reason for `RatioSumError`)
- multiple height calculations are unnecessary as the height is expected to remain the same