### PR TITLE
how do we vertically align text

### DIFF
--- a/src/elements/paragraph.ts
+++ b/src/elements/paragraph.ts
@@ -43,6 +43,11 @@ export class Paragraph implements Element {
   }
 
   draw(context: Context, box: BoundingBox): void {
+    if (this.style.verticalAlignment) {
+      const height = this.height(context, box);
+      box.y += Math.floor((box.height - height) / 2);
+    }
+
     context.withFont(this.style, () => {
       return context.raw.text(this.text, box.x, box.y, this.textOptions(box));
     });

--- a/src/utils/font.ts
+++ b/src/utils/font.ts
@@ -13,6 +13,7 @@ export interface FontStyle {
   fontColor?: ColorValue;
   letterSpacing?: number;
   lineHeight?: number;
+  verticalAlignment?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Problem
Sometimes with table rows, some columns might have more text than others, hence they'll define the height of the entire row. This makes the table look quite unusable as it's difficult to track which columns share a row